### PR TITLE
Add an option to disable extra uri checking and redirect following, m…

### DIFF
--- a/test/specified_timegate_direct_timegate_query_testdata.csv
+++ b/test/specified_timegate_direct_timegate_query_testdata.csv
@@ -1,0 +1,6 @@
+"Input URI-R", "Accept-Datetime", "Input URI-G", "Expected URI-M"
+"http://www.lanl.gov","Wed, 19 Mar 2003 23:59:59 GMT","http://www.web.archive.org/web/","http://www.web.archive.org/web/20030320195439/http://www.lanl.gov/"
+"http://www.cnn.com","Tue, 28 Jul 1998 17:18:49 GMT","http://web.archive.org/web/","http://web.archive.org/web/20000620180259/http://cnn.com/"
+"http://www.huffingtonpost.com","Tue, 14 Jan 2003 10:31:44 GMT","http://web.archive.org/web/","http://web.archive.org/web/20050422005938/http://www.huffingtonpost.com/"
+"http://slacvm.slac.stanford.edu/FIND/slac.html","Mon, 06 Sep 1993 00:00:00 GMT","https://swap.stanford.edu/","https://swap.stanford.edu/19930908000000/http://slacvm.slac.stanford.edu/FIND/slac.html"
+"http://vvork.com/","Mon, 06 Sep 1993 00:00:00 GMT","http://webenact.rhizome.org/vvork/","http://webenact.rhizome.org/vvork/20141006184357/http://www.vvork.com/"

--- a/test/test_memento_client.py
+++ b/test/test_memento_client.py
@@ -44,6 +44,10 @@ specified_timegate_testdata = load_testdata(
     "test/specified_timegate_testdata.csv",
     [ "Input URI-R", "Accept-Datetime", "Input URI-G", "Expected URI-M" ] )
 
+specified_timegate_direct_timegate_query_testdata = load_testdata(
+    "test/specified_timegate_direct_timegate_query_testdata.csv",
+    [ "Input URI-R", "Accept-Datetime", "Input URI-G", "Expected URI-M" ] )
+
 native_timegate_testdata = load_testdata(
     "test/native_timegate_testdata.csv",
     [ "Input URI-R", "Accept-Datetime", "Expected URI-G" ] )
@@ -78,6 +82,15 @@ def test_get_memento_uri_specified_timegate(input_uri_r, input_datetime, input_t
     mc = MementoClient(timegate_uri=input_timegate, check_native_timegate=False)
 
     actual_uri_m = mc.get_memento_info(input_uri_r, input_datetime).get("mementos").get("closest").get("uri")[0]
+
+    assert expected_uri_m == actual_uri_m
+
+@pytest.mark.parametrize("input_uri_r,input_datetime,input_timegate,expected_uri_m", specified_timegate_direct_timegate_query_testdata)
+def test_get_memento_uri_specified_timegate_direct_timegate_query(input_uri_r, input_datetime, input_timegate, expected_uri_m):
+
+    mc = MementoClient(timegate_uri=input_timegate, check_native_timegate=False)
+
+    actual_uri_m = mc.get_memento_info(input_uri_r, input_datetime, include_uri_checks=False).get("mementos").get("closest").get("uri")[0]
 
     assert expected_uri_m == actual_uri_m
 


### PR DESCRIPTION
…aking a single request to the timegate, closes #2. Allows for more efficient querying of the TimeGate with a single HTTP request. See #2 for more details.
