### PR TITLE
Add support for relative url `Location` redirection

### DIFF
--- a/memento_client/memento_client.py
+++ b/memento_client/memento_client.py
@@ -12,9 +12,9 @@ import os
 
 # Python 2.7 and 3.X support are different for urlparse
 if sys.version_info[0] == 3:
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, urljoin
 else:
-    from urlparse import urlparse
+    from urlparse import urlparse, urljoin
 
 if os.environ.get('DEBUG_MEMENTO_CLIENT') == '1':
     logging.basicConfig(level=logging.DEBUG)
@@ -281,10 +281,10 @@ class MementoClient(object):
                 """
                 a recursive func to follow redirects.
                 """
-                logging.debug("Following to new URI of " +
-                              org_response.headers.get("Location"))
-                return self.get_native_timegate_uri(
-                    org_response.headers.get('Location'), accept_datetime)
+                absolute_url = urljoin(original_uri,
+                                       org_response.headers.get('Location'))
+                logging.debug("Following to new URI of " + absolute_url)
+                return self.get_native_timegate_uri(absolute_url, accept_datetime)
 
             if org_response.headers.get("Vary") and\
                     'accept-datetime' in org_response.headers.get('Vary').lower():

--- a/test/test_memento_client.py
+++ b/test/test_memento_client.py
@@ -211,3 +211,13 @@ def test_close_session_on_default(mock_session):
         urir = mc.get_original_uri('http://www.cnn.com')
 
     mock_session.close.assert_called_with()
+
+def test_relative_url_redirection():
+    input_uri_r = "http://httpbin.org/redirect/1"
+
+    mc = MementoClient()
+    dt = datetime.datetime.strptime("Tue, 11 Sep 2001 08:45:45 GMT", "%a, %d %b %Y %H:%M:%S GMT")
+
+    uri_m = mc.get_memento_info(input_uri_r, dt).get("mementos").get("closest").get("uri")[0]
+
+    assert uri_m == 'https://web.archive.org/web/20111202113952/http://www.httpbin.org:80/get'


### PR DESCRIPTION
Add support for relative url `Location` redirection in
`follow()` using `uritools.urijoin`.

Fixes https://github.com/mementoweb/py-memento-client/issues/11