### PR TITLE
Add wheel build support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Add setup.cfg `[bdist_wheel]`, so we can build memento_client
package into a whl file.

Closes https://github.com/mementoweb/py-memento-client/issues/20